### PR TITLE
Fix parser for array out-of-bounds access panic

### DIFF
--- a/gotty.go
+++ b/gotty.go
@@ -110,7 +110,7 @@ func (term *TermInfo) GetAttributeName(name string) (stacker, error) {
 	return term.GetAttribute(tc)
 }
 
-// A utility function that finds and returns the termcap equivalent of a 
+// A utility function that finds and returns the termcap equivalent of a
 // variable name.
 func GetTermcapName(name string) string {
 	// Termcap name

--- a/gotty.go
+++ b/gotty.go
@@ -8,6 +8,7 @@ package gotty
 // TODO add more concurrency to name lookup, look for more opportunities.
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -230,9 +231,14 @@ func readTermInfo(path string) (*TermInfo, error) {
 	// We get an offset, and then iterate until the string is null-terminated
 	for i, offset := range shArray {
 		if offset > -1 {
-			r := offset
-			for ; byteArray[r] != 0; r++ {
+			if int(offset) >= len(byteArray) {
+				return nil, errors.New("array out of bounds reading string section")
 			}
+			r := bytes.IndexByte(byteArray[offset:], 0)
+			if r == -1 {
+				return nil, errors.New("missing nul byte reading string section")
+			}
+			r += int(offset)
 			term.strAttributes[StrAttr[i*2+1]] = string(byteArray[offset:r])
 		}
 	}

--- a/gotty.go
+++ b/gotty.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"reflect"
 	"strings"
 	"sync"
@@ -24,21 +24,19 @@ import (
 func OpenTermInfo(termName string) (*TermInfo, error) {
 	// Find the environment variables
 	if termloc := os.Getenv("TERMINFO"); len(termloc) > 0 {
-		path := filepath.Join(termloc, string(termName[0]), termName)
-		return readTermInfo(path)
+		return readTermInfo(path.Join(termloc, string(termName[0]), termName))
 	} else {
 		// Search like ncurses
 		locations := []string{}
 		if h := os.Getenv("HOME"); len(h) > 0 {
-			locations = append(locations, filepath.Join(h, ".terminfo"))
+			locations = append(locations, path.Join(h, ".terminfo"))
 		}
 		locations = append(locations,
 			"/etc/terminfo/",
 			"/lib/terminfo/",
 			"/usr/share/terminfo/")
 		for _, str := range locations {
-			path := filepath.Join(str, string(termName[0]), termName)
-			term, err := readTermInfo(path)
+			term, err := readTermInfo(path.Join(str, string(termName[0]), termName))
 			if err == nil {
 				return term, nil
 			}

--- a/gotty.go
+++ b/gotty.go
@@ -192,7 +192,9 @@ func readTermInfo(path string) (*TermInfo, error) {
 		}
 	}
 	// If the number of bytes read is not even, a byte for alignment is added
-	if len(byteArray)%2 != 0 {
+	// We know the header is an even number of bytes so only need to check the
+	// total of the names and booleans.
+	if (header[1]+header[2])%2 != 0 {
 		err = binary.Read(file, binary.LittleEndian, make([]byte, 1))
 		if err != nil {
 			return nil, err

--- a/gotty.go
+++ b/gotty.go
@@ -22,11 +22,11 @@ import (
 // If something went wrong reading the terminfo database file, an error is
 // returned.
 func OpenTermInfo(termName string) (*TermInfo, error) {
-	var term *TermInfo
-	var err error
 	// Find the environment variables
-	termloc := os.Getenv("TERMINFO")
-	if len(termloc) == 0 {
+	if termloc := os.Getenv("TERMINFO"); len(termloc) > 0 {
+		path := filepath.Join(termloc, string(termName[0]), termName)
+		return readTermInfo(path)
+	} else {
 		// Search like ncurses
 		locations := []string{}
 		if h := os.Getenv("HOME"); len(h) > 0 {
@@ -38,14 +38,13 @@ func OpenTermInfo(termName string) (*TermInfo, error) {
 			"/usr/share/terminfo/")
 		for _, str := range locations {
 			path := filepath.Join(str, string(termName[0]), termName)
-			term, err = readTermInfo(path)
+			term, err := readTermInfo(path)
 			if err == nil {
 				return term, nil
 			}
 		}
 		return nil, errors.New("No terminfo file(-location) found")
 	}
-	return term, err
 }
 
 // Open a terminfo file from the environment variable containing the current

--- a/gotty.go
+++ b/gotty.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -27,12 +28,16 @@ func OpenTermInfo(termName string) (*TermInfo, error) {
 	termloc := os.Getenv("TERMINFO")
 	if len(termloc) == 0 {
 		// Search like ncurses
-		locations := []string{os.Getenv("HOME") + "/.terminfo/", "/etc/terminfo/",
-			"/lib/terminfo/", "/usr/share/terminfo/"}
+		locations := []string{
+			filepath.Join(os.Getenv("HOME"), ".terminfo"),
+			"/etc/terminfo/",
+			"/lib/terminfo/",
+			"/usr/share/terminfo/",
+		}
 		var path string
 		for _, str := range locations {
 			// Construct path
-			path = str + string(termName[0]) + "/" + termName
+			path = filepath.Join(str, string(termName[0]), termName)
 			// Check if path can be opened
 			file, _ := os.Open(path)
 			if file != nil {

--- a/gotty.go
+++ b/gotty.go
@@ -22,6 +22,9 @@ import (
 // If something went wrong reading the terminfo database file, an error is
 // returned.
 func OpenTermInfo(termName string) (*TermInfo, error) {
+	if len(termName) == 0 {
+		return nil, errors.New("No termname given")
+	}
 	// Find the environment variables
 	if termloc := os.Getenv("TERMINFO"); len(termloc) > 0 {
 		return readTermInfo(path.Join(termloc, string(termName[0]), termName))

--- a/gotty.go
+++ b/gotty.go
@@ -28,12 +28,14 @@ func OpenTermInfo(termName string) (*TermInfo, error) {
 	termloc := os.Getenv("TERMINFO")
 	if len(termloc) == 0 {
 		// Search like ncurses
-		locations := []string{
-			filepath.Join(os.Getenv("HOME"), ".terminfo"),
+		locations := []string{}
+		if h := os.Getenv("HOME"); len(h) > 0 {
+			locations = append(locations, filepath.Join(h, ".terminfo"))
+		}
+		locations = append(locations,
 			"/etc/terminfo/",
 			"/lib/terminfo/",
-			"/usr/share/terminfo/",
-		}
+			"/usr/share/terminfo/")
 		for _, str := range locations {
 			path := filepath.Join(str, string(termName[0]), termName)
 			term, err = readTermInfo(path)

--- a/gotty.go
+++ b/gotty.go
@@ -34,23 +34,14 @@ func OpenTermInfo(termName string) (*TermInfo, error) {
 			"/lib/terminfo/",
 			"/usr/share/terminfo/",
 		}
-		var path string
 		for _, str := range locations {
-			// Construct path
-			path = filepath.Join(str, string(termName[0]), termName)
-			// Check if path can be opened
-			file, _ := os.Open(path)
-			if file != nil {
-				// Path can open, fall out and use current path
-				file.Close()
-				break
+			path := filepath.Join(str, string(termName[0]), termName)
+			term, err = readTermInfo(path)
+			if err == nil {
+				return term, nil
 			}
 		}
-		if len(path) > 0 {
-			term, err = readTermInfo(path)
-		} else {
-			err = errors.New(fmt.Sprintf("No terminfo file(-location) found"))
-		}
+		return nil, errors.New("No terminfo file(-location) found")
 	}
 	return term, err
 }


### PR DESCRIPTION
I tripped over a panic which was down to my rxvt-unicode terminfo file (on Debian) having an odd length name string but an even number of booleans, meaning the code expected an alignment byte where none was actually present and then later got confused.

This PR fixes that and also updates the string array parsing code to be more robust against bogus offsets in the input. Also fixes a w/space issues.